### PR TITLE
Fix XML misformatting for the repo manifest

### DIFF
--- a/Fairphone-2-Developer-Information.md
+++ b/Fairphone-2-Developer-Information.md
@@ -51,13 +51,14 @@ Next, `mkdir .repo/local_manifests`, then create the file `.repo/local_manifests
 
   <remote name="smoose"
         fetch="http://github.com/smoose-nils"
-        revision="refs/heads/ubp-5.1" />
+        revision="refs/heads/ubp-5.1" >
 
   <project path="kernel/fairphone/FP2" name="android_kernel_fairphone_fp2" remote="ubp" />
   <project path="device/fairphone/FP2" name="android_device_fairphone_fp2" remote="ubp"  />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="cm" />
   <project path="vendor/fairphone" name="proprietary_vendor_fairphone" remote="smoose"/>
-  </manifest>
+  </remote>
+</manifest>
 ```
 
 Then, run `repo sync -j4` (increase the job value if your computer and Internet connection can handle it). It'll download about 20GB of sources.

--- a/Fairphone-2-Developer-Information.md
+++ b/Fairphone-2-Developer-Information.md
@@ -51,13 +51,12 @@ Next, `mkdir .repo/local_manifests`, then create the file `.repo/local_manifests
 
   <remote name="smoose"
         fetch="http://github.com/smoose-nils"
-        revision="refs/heads/ubp-5.1" >
+        revision="refs/heads/ubp-5.1" />
 
-  <project path="kernel/fairphone/FP2" name="android_kernel_fairphone_fp2" remote="ubp" />
-  <project path="device/fairphone/FP2" name="android_device_fairphone_fp2" remote="ubp"  />
+  <project path="kernel/fairphone/FP2" name="ubports/android_kernel_fairphone_fp2" remote="ubp" />
+  <project path="device/fairphone/FP2" name="ubports/android_device_fairphone_fp2" remote="ubp"  />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="cm" />
   <project path="vendor/fairphone" name="proprietary_vendor_fairphone" remote="smoose"/>
-  </remote>
 </manifest>
 ```
 


### PR DESCRIPTION
The XML manifest specified on the "wiki/Fairphone-2-Developer-Information" page is incorrect. This pull request corrects it.