### PR TITLE
Sort bug-tracker list alphabetically

### DIFF
--- a/UBports-Bug-Trackers.md
+++ b/UBports-Bug-Trackers.md
@@ -6,33 +6,33 @@ Issues with the operating system are tracked [here](https://github.com/ubports/u
 
 ## Core Apps
 
-* [OpenStore](https://github.com/UbuntuOpenStore/openstore-meta)
-* [Browser (Oxide)](https://github.com/ubports/webbrowser-component/issues)
-* [Telegram](https://github.com/yunit-io/telegram-app/issues)
-* [Music](https://github.com/ubports/music-app/issues)
-* [Messaging](https://github.com/ubports/messaging-app/issues)
-* [Dialer](https://github.com/ubports/dialer-app/issues)
-* [Camera](https://github.com/ubports/camera-app/issues)
-* [Mediaplayer](https://github.com/ubports/mediaplayer-app/issues)
-* [Gallery](https://github.com/ubports/gallery-app/issues)
 * [Address-Book](https://github.com/ubports/address-book-app/issues)
-* [File Manager](https://github.com/ubports/filemanager-app/issues)
-* [Terminal](https://github.com/ubports/terminal-app/issues)
-* [Document Viewer](https://github.com/ubports/docviewer-app/issues)
-* [Notes](https://github.com/ubports/notes-app/issues)
-* [Weather](https://github.com/ubports/weather-app/issues)
-* [Clock](https://github.com/ubports/clock-app/issues)
+* [Browser (Oxide)](https://github.com/ubports/webbrowser-component/issues)
 * [Calculator](https://github.com/ubports/calculator-app/issues)
 * [Calendar](https://github.com/ubports/calendar-app/issues)
+* [Camera](https://github.com/ubports/camera-app/issues)
+* [Clock](https://github.com/ubports/clock-app/issues)
+* [Dialer](https://github.com/ubports/dialer-app/issues)
+* [Document Viewer](https://github.com/ubports/docviewer-app/issues)
+* [File Manager](https://github.com/ubports/filemanager-app/issues)
+* [Gallery](https://github.com/ubports/gallery-app/issues)
+* [Mediaplayer](https://github.com/ubports/mediaplayer-app/issues)
+* [Messaging](https://github.com/ubports/messaging-app/issues)
+* [Music](https://github.com/ubports/music-app/issues)
+* [Notes](https://github.com/ubports/notes-app/issues)
+* [OpenStore](https://github.com/UbuntuOpenStore/openstore-meta/issues)
 * [Sudoku](https://github.com/ubports/sudoku-app/issues)
+* [Telegram](https://github.com/yunit-io/telegram-app/issues)
+* [Terminal](https://github.com/ubports/terminal-app/issues)
+* [Weather](https://github.com/ubports/weather-app/issues)
 
 ## Website problems
 
 If there's an issue with any of the UBports websites (this could include anything from rendering problems to typos), please report it in the relevant issue tracker:
 
+* [OpenStore](https://github.com/UbuntuOpenStore/openstore-meta/issues)
 * [ubports.com](https://github.com/ubports/ubports.com/issues)
-* [OpenStore](https://github.com/UbuntuOpenStore/openstore-meta)
 * [devices.ubports.com](https://github.com/ubports/devices.ubports.com/issues)
-* [blog.ubports.com](https://github.com/ubports/blog.ubports.com)
-* [wiki.ubports.com](https://github.com/ubports/wiki.ubports.com).
+* [blog.ubports.com](https://github.com/ubports/blog.ubports.com/issues)
 * [stats.ubports.com](https://github.com/ubports/stats.ubports.com/issues)
+* [wiki.ubports.com](https://github.com/ubports/wiki.ubports.com/issues)


### PR DESCRIPTION
Note: OpenStore only has one bug tracker (web+app) -> updated links directly to "issues"